### PR TITLE
Add Zenity frequency selection dialog to QSSTV startup

### DIFF
--- a/MissionControllerUI/src/main/java/org/ariss/star/MissionController.java
+++ b/MissionControllerUI/src/main/java/org/ariss/star/MissionController.java
@@ -194,7 +194,17 @@ public class MissionController {
                 // Watch the qsstv process and cleanup when it exits
                 qsstvWatcherThread = new Thread(() -> {
                     try {
-                        if (qsstv != null) qsstv.waitFor();
+                        int exitCode = qsstv != null ? qsstv.waitFor() : 1;
+                        // Exit code 1 means the user cancelled the frequency dialog — just reset UI
+                        if (exitCode == 1) {
+                            Platform.runLater(() -> {
+                                qsstv_checkbox.setSelected(false);
+                                recAPRSCheckBox.setDisable(false);
+                            });
+                            qsstv = null;
+                            qsstvWatcherThread = null;
+                            return;
+                        }
                     } catch (InterruptedException ignored) {}
                     runExternalCleanup();
                 });

--- a/start_qsstv.sh
+++ b/start_qsstv.sh
@@ -1,9 +1,36 @@
 #!/bin/bash
-# script to decode SSTV using rtl_fm and QSSTV from the C
+# script to decode SSTV using rtl_fm and QSSTV from the CubeSatSim Camera Module
 
 echo "Script to decode SSTV from the CubeSatSim for ARISS Radio Pi"
 
 echo
+
+# Prompt the user to select a receive frequency via Zenity dialog
+FREQ=$(zenity --list \
+    --title="Select SSTV Frequency" \
+    --text="Select the XRP Camera Module frequency to receive:" \
+    --column="Participant" --column="Frequency (MHz)" \
+    --width=380 --height=420 \
+    "Default" "434.90" \
+    "1"       "434.91" \
+    "2"       "434.92" \
+    "3"       "434.93" \
+    "4"       "434.94" \
+    "5"       "434.95" \
+    "6"       "434.89" \
+    "7"       "434.88" \
+    "8"       "434.87" \
+    "9"       "434.86" \
+    "10"      "434.85" \
+    --print-column=2 2>/dev/null)
+
+# If the user closed/cancelled the dialog, exit without starting QSSTV
+if [ -z "$FREQ" ]; then
+    echo "No frequency selected. Exiting."
+    exit 1
+fi
+
+echo "Selected frequency: ${FREQ} MHz"
 
 sudo systemctl stop openwebrx
 
@@ -31,6 +58,6 @@ LOOPBACK_CARD=$(aplay -l | grep "Loopback" | grep -oP 'card \K\d+' | head -1)
 echo "Using Loopback card: $LOOPBACK_CARD"
 
 #rtl_fm -M fm -f 434.9M -s 48k | aplay -D hw:2,0,0 -r 48000 -t raw -f S16_LE -c 1 &
-rtl_fm -M fm -f 434.9M -s 48k | aplay -D hw:${LOOPBACK_CARD},0,0 -r 48000 -t raw -f S16_LE -c 1
+rtl_fm -M fm -f ${FREQ}M -s 48k | aplay -D hw:${LOOPBACK_CARD},0,0 -r 48000 -t raw -f S16_LE -c 1
 
 $SHELL


### PR DESCRIPTION
When the Open QSSTV checkbox is clicked, a Zenity list dialog now prompts the user to select one of 11 CubeSatSim frequencies (434.85– 434.95 MHz) before starting rtl_fm and QSSTV. Cancelling the dialog resets the checkbox cleanly without triggering cleanup.